### PR TITLE
Added support for custom masked character.

### DIFF
--- a/MaskedEditText/res/values/attrs.xml
+++ b/MaskedEditText/res/values/attrs.xml
@@ -3,5 +3,6 @@
 	<declare-styleable name="MaskedEditText">
 		<attr name="mask" format="string" />
 		<attr name="char_representation" format="string" />
+		<attr name="mask_fill" format="string" />
 	</declare-styleable>
 </resources>

--- a/MaskedEditText/src/br/com/sapereaude/maskedEditText/MaskedEditText.java
+++ b/MaskedEditText/src/br/com/sapereaude/maskedEditText/MaskedEditText.java
@@ -14,6 +14,7 @@ import android.widget.TextView;
 public class MaskedEditText extends EditText implements TextWatcher {
 
 	private String mask;
+	private char maskFill;
 	private char charRepresentation;
 	private int[] rawToMask;
 	private RawText rawText;
@@ -41,6 +42,9 @@ public class MaskedEditText extends EditText implements TextWatcher {
 		
 		TypedArray attributes = context.obtainStyledAttributes(attrs, R.styleable.MaskedEditText);
 		mask = attributes.getString(R.styleable.MaskedEditText_mask);
+		String maskFill = attributes.getString(R.styleable.MaskedEditText_mask_fill);
+		this.maskFill = (maskFill != null) ? maskFill.charAt(0) : ' ';
+
 		String representation = attributes.getString(R.styleable.MaskedEditText_char_representation);
 		
 		if(representation == null) {
@@ -325,7 +329,7 @@ public class MaskedEditText extends EditText implements TextWatcher {
 				maskedText[rawToMask[i]] = rawText.charAt(i);
 			}
 			else {
-				maskedText[rawToMask[i]] = ' ';
+				maskedText[rawToMask[i]] = maskFill;
 			}
 		}
 		return new String(maskedText);

--- a/MaskedEditText/src/br/com/sapereaude/maskedEditText/MaskedEditText.java
+++ b/MaskedEditText/src/br/com/sapereaude/maskedEditText/MaskedEditText.java
@@ -42,8 +42,9 @@ public class MaskedEditText extends EditText implements TextWatcher {
 		
 		TypedArray attributes = context.obtainStyledAttributes(attrs, R.styleable.MaskedEditText);
 		mask = attributes.getString(R.styleable.MaskedEditText_mask);
+		
 		String maskFill = attributes.getString(R.styleable.MaskedEditText_mask_fill);
-		this.maskFill = (maskFill != null) ? maskFill.charAt(0) : ' ';
+		this.maskFill = (maskFill != null && maskFill.length() > 0) ? maskFill.charAt(0) : ' ';
 
 		String representation = attributes.getString(R.styleable.MaskedEditText_char_representation);
 		

--- a/README.markdown
+++ b/README.markdown
@@ -38,7 +38,7 @@ You can also optionally replace the ` ` character on the mask for any kind of ch
         android:layout_height="wrap_content"
         mask:mask="ccc.ccc.ccc-cc"
         mask:char_representation="c"
-	mask:mask_fill="_"
+        mask:mask_fill="_"
     />
 
 You can also change the mask and the representation character programatically:
@@ -91,7 +91,7 @@ Você também pode mudar o character ` ` que é utilizado para representar espa�
         android:layout_height="wrap_content"
         mask:mask="ccc.ccc.ccc-cc"
         mask:char_representation="c"
-	mask:mask_fill="_"
+        mask:mask_fill="_"
     />
 
 Você também pode mudar a máscara e o caracter de representação programaticamente:

--- a/README.markdown
+++ b/README.markdown
@@ -31,6 +31,16 @@ You can optionally set the representation character (in case you don't want to u
         mask:char_representation="c"
     />
 
+You can also optionally replace the ` ` character on the mask for any kind of character:
+
+    <br.com.sapereaude.maskedEditText.MaskedEditText 
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        mask:mask="ccc.ccc.ccc-cc"
+        mask:char_representation="c"
+	mask:mask_fill="_"
+    />
+
 You can also change the mask and the representation character programatically:
 
 	MaskedEditText editText = (MaskedEditText) findViewById(R.id.my_edit_text)
@@ -72,6 +82,16 @@ Caso seja do seu interesse você pode mudar o caracter de representação (se vo
         android:layout_height="wrap_content"
         mask:mask="ccc.ccc.ccc-cc"
         mask:char_representation="c"
+    />
+
+Você também pode mudar o character ` ` que é utilizado para representar espaço em branco na máscara:
+
+    <br.com.sapereaude.maskedEditText.MaskedEditText 
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        mask:mask="ccc.ccc.ccc-cc"
+        mask:char_representation="c"
+	mask:mask_fill="_"
     />
 
 Você também pode mudar a máscara e o caracter de representação programaticamente:


### PR DESCRIPTION
I've just added a support for custom masked character (i.e. instead of ` `, you can use `_`).

The mask `##.##.####` without `mark_fill` attribute would like `  .  .    ` without any content.
If the `mark_fill` attribute has `_` as marker filler, it would look like `__.__.____`.